### PR TITLE
Sort imports; expand unit-test

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -46,8 +46,8 @@ from .primitives import (
     String,
     Word,
 )
+from .repeater import CountRepeater, Repeater, TimeRepeater
 from .sessions import open_test_run, Session, Target
-from .repeater import Repeater, CountRepeater, TimeRepeater
 
 __all__ = [
     "BasePrimitive",
@@ -146,8 +146,8 @@ __all__ = [
     "String",
     "SullyRuntimeError",
     "Target",
-    "TimeRepeater",
     "TCPSocketConnection",
+    "TimeRepeater",
     "UDPSocketConnection",
     "Word",
 ]

--- a/boofuzz/repeater.py
+++ b/boofuzz/repeater.py
@@ -1,6 +1,7 @@
-from abc import abstractmethod, ABCMeta
-from six import with_metaclass
 import time
+from abc import ABCMeta, abstractmethod
+
+from six import with_metaclass
 
 
 class Repeater(with_metaclass(ABCMeta, object)):

--- a/docs/source/Target.rst
+++ b/docs/source/Target.rst
@@ -1,6 +1,5 @@
 Target
 ======
-
 .. autoclass:: boofuzz.Target
     :members:
     :undoc-members:
@@ -8,7 +7,6 @@ Target
 
 Repeater
 --------
-
 .. autoclass:: boofuzz.repeater.Repeater
    :members:
    :undoc-members:
@@ -16,11 +14,15 @@ Repeater
 
 The following concrete implementations of this interface are available:
 
+TimeRepeater
+------------
 .. autoclass:: boofuzz.repeater.TimeRepeater
    :members:
    :undoc-members:
    :show-inheritance:
 
+CountRepeater
+-------------
 .. autoclass:: boofuzz.repeater.CountRepeater
    :members:
    :undoc-members:

--- a/unit_tests/test_target.py
+++ b/unit_tests/test_target.py
@@ -1,13 +1,15 @@
 import time
 import unittest
 
+from boofuzz import CountRepeater, Target, TimeRepeater
 from boofuzz.connections import ITargetConnection
-from boofuzz import Target, TimeRepeater, CountRepeater
 
 
 class MockCountConnection(ITargetConnection):
     def __init__(self):
         self.count = 0
+        self.first = None
+        self.second = None
 
     def close(self):
         pass
@@ -20,15 +22,20 @@ class MockCountConnection(ITargetConnection):
 
     def send(self, data):
         self.count += 1
+        if self.first is None:
+            self.first = time.time()
+        elif self.second is None:
+            self.second = time.time()
 
     @property
     def info(self):
-        pass
+        return
 
 
 class MockTimeConnection(ITargetConnection):
     def __init__(self):
         self.first = None
+        self.second = None
         self.last = None
 
     def close(self):
@@ -43,27 +50,38 @@ class MockTimeConnection(ITargetConnection):
     def send(self, data):
         if self.first is None:
             self.first = time.time()
+        elif self.second is None:
+            self.second = time.time()
         self.last = time.time()
 
     @property
     def info(self):
-        pass
+        return
 
 
 class TestTarget(unittest.TestCase):
+    SLEEP_TIME = 0.01
+
     def test_count_repeater(self):
-        repeater = CountRepeater(5)
+        repeater = CountRepeater(count=5, sleep_time=self.SLEEP_TIME)
         connection = MockCountConnection()
         target = Target(connection, repeater=repeater)
 
         target.send(b"This is a test")
 
         self.assertEqual(repeater.count, connection.count)
+        self.assertGreaterEqual(connection.second - connection.first, self.SLEEP_TIME)
+        with self.assertRaises(ValueError):
+            CountRepeater(count=0)
 
     def test_time_repeater(self):
-        repeater = TimeRepeater(5)
+        repeater = TimeRepeater(duration=0.05, sleep_time=self.SLEEP_TIME)
         connection = MockTimeConnection()
         target = Target(connection, repeater=repeater)
 
         target.send(b"This is a test")
+
         self.assertLessEqual(connection.last - connection.first, repeater.duration)
+        self.assertGreaterEqual(connection.second - connection.first, self.SLEEP_TIME)
+        with self.assertRaises(ValueError):
+            TimeRepeater(duration=0)


### PR DESCRIPTION
I didn't want to push those changes directly to your branch, hence the PR.

The unit-test now also includes testing of the error handling and the sleep-time. Overall test time was reduced too.

After rendering the docs, it felt like a heading was missing for the two repeater classes, so I added some. The headings one size smaller are sadly really small so I had to go with the same as the Repeater class has got.